### PR TITLE
fix(cli): correct sintax typo to syntax in createFiles error

### DIFF
--- a/main.js
+++ b/main.js
@@ -56,7 +56,7 @@ const createFiles = (name, file) => {
     createFolder(name, basePath);
     const { model, resource } = require(file);
     if (model == null || resource == null) {
-      console.error(`Template model "${name}" has sintax error.`);
+      console.error(`Template model "${name}" has syntax error.`);
       process.exit(-1);
     }
     let valid = Types.modelIsValid(model);


### PR DESCRIPTION
Fixes the user-facing typo in the error message printed by `createFiles()` when a model template is invalid.

- `Template model "x" has sintax error.` → `has syntax error.`

Verified: eslint clean, jest 26/26 pass, and an end-to-end CLI run with a broken model file now prints `Template model "broken-model" has syntax error.`

Kanban card: #30