### PR TITLE
chore(deps): bump eslint-plugin-prettier from 3.1.1 to 3.4.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1771,9 +1771,9 @@
       }
     },
     "eslint-plugin-prettier": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.1.tgz",
-      "integrity": "sha512-A+TZuHZ0KU0cnn56/9mfR7/KjUJ9QNVXUhwvRFSR7PGPe0zQR6PTkmyqg1AtUUEOzTqeRsUwyKFh0oVZKVCrtA==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.4.1.tgz",
+      "integrity": "sha512-htg25EUYUeIhKHXjOinK4BgCcDwtLHjqaxCDsMy5nbnUMkKFvIhMVCp+5GFUXQ4Nr8lBsPqtGAqBenbpFqAA2g==",
       "dev": true,
       "requires": {
         "prettier-linter-helpers": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "coveralls": "^3.0.9",
     "eslint": "^6.6.0",
     "eslint-config-prettier": "^6.5.0",
-    "eslint-plugin-prettier": "^3.1.1",
+    "eslint-plugin-prettier": "^3.4.1",
     "eslint-plugin-vue": "^6.0.1",
     "faker": "^4.1.0",
     "jest": "^24.9.0",


### PR DESCRIPTION
Bumps the lint toolchain plugin to the latest 3.x release (compatible with the pinned eslint 6 + prettier 1.19). Dependency set unchanged, so the lockfileVersion-1 lockfile is edited in place (4-line diff total).

Verified:
- `npm ci` accepts the lockfile and installs 3.4.1
- `npx eslint main.js js test` clean with the new plugin
- negative test: `prettier/prettier` rule still flags bad formatting (exit 1)
- jest 30/30 pass, CLI smoke (`--version`) fine