### PR TITLE
chore(deps): bump eslint-config-prettier from 6.5.0 to 6.15.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1762,9 +1762,9 @@
       }
     },
     "eslint-config-prettier": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.5.0.tgz",
-      "integrity": "sha512-cjXp8SbO9VFGW/Z7mbTydqS9to8Z58E5aYhj3e1+Hx7lS9s6gL5ILKNpCqZAFOVYRcSkWPFYljHrEh8QFEK5EQ==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.15.0.tgz",
+      "integrity": "sha512-a1+kOYLR8wMGustcgAjdydMsQ2A/2ipRPwRKUmfYaSxc9ZPcrku080Ctl6zrZzZNs/U82MjSv+qKREkoq3bJaw==",
       "dev": true,
       "requires": {
         "get-stdin": "^6.0.0"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "devDependencies": {
     "coveralls": "^3.0.9",
     "eslint": "^6.6.0",
-    "eslint-config-prettier": "^6.5.0",
+    "eslint-config-prettier": "^6.15.0",
     "eslint-plugin-prettier": "^3.1.1",
     "eslint-plugin-vue": "^6.0.1",
     "faker": "^4.1.0",


### PR DESCRIPTION
Bumps the prettier-compat config to the latest 6.x release (final 6.x line, for the eslint 6 toolchain). Dependency set unchanged (`get-stdin ^6.0.0` already locked), so the lockfileVersion-1 lockfile is edited in place — 4-line diff total.

Verified:
- `npm ci` installs 6.15.0 from the edited lock
- `npx eslint main.js js test` clean (config is exercised via `plugin:prettier/recommended`)
- jest 30/30 pass, CLI smoke (`--version`) fine

Complements #33 (eslint-plugin-prettier 3.4.1) — lockfile hunks touch different sections, merge cleanly.