### PR TITLE
test(templates): cover Service and Vuex Module getTemplate()

### DIFF
--- a/test/templates.test.js
+++ b/test/templates.test.js
@@ -1,0 +1,35 @@
+const Service = require("../js/service/service");
+const Module = require("../js/store/module");
+
+describe("Service template", () => {
+  test("renders CRUD service helpers for the resource", () => {
+    const service = new Service({
+      name: "book",
+      resource: { endPoint: "books" }
+    });
+
+    const template = service.getTemplate();
+
+    expect(template).toMatch('import service from "@/services/httpService";');
+    expect(template).toMatch('const END_POINT = "/books";');
+    expect(template).toMatch("const getBook = id =>");
+    expect(template).toMatch("const getAllBooks = params =>");
+    expect(template).toMatch(/createBook/);
+    expect(template).toMatch(/updateBook/);
+    expect(template).toMatch(/deleteBook/);
+  });
+});
+
+describe("Vuex store module template", () => {
+  test("renders state, getters and actions for the model", () => {
+    const vuexModule = new Module({ name: "book" });
+
+    const template = vuexModule.getTemplate();
+
+    expect(template).toMatch('} from "@/services/book";');
+    expect(template).toMatch("books: []");
+    expect(template).toMatch("getAllBooks(");
+    expect(template).toMatch('"SET_BOOKS"');
+    expect(template).toMatch('"CREATED_BOOK"');
+  });
+});


### PR DESCRIPTION
Adds focused unit tests for the two pure template builders that had zero coverage:

- `js/service/service.js` — generated service exposes `getBook`, `getAllBooks`, `createBook`, `updateBook`, `deleteBook` against `END_POINT = "/books"` with the httpService import
- `js/store/module.js` — generated Vuex module imports from `@/services/book`, declares `books: []` state, `getAllBooks(` getter/action, and `SET_BOOKS` / `CREATED_BOOK` mutation commits

No production changes. jest 32/32 across 6 suites on this branch (30 master + 2 new; PRs #38/#39 add more elsewhere), eslint clean, CLI smoke fine.