### PR TITLE
test(scaffold): cover httpService, store and eslintrc templates

### DIFF
--- a/test/scaffold_templates.test.js
+++ b/test/scaffold_templates.test.js
@@ -1,0 +1,46 @@
+const HttpService = require("../js/service/httpService");
+const IndexStore = require("../js/store/indexStore");
+const IndexModule = require("../js/store/indexModule");
+const Eslintrc = require("../js/eslint/eslintrc");
+
+describe("httpService template", () => {
+  test("creates an axios instance with base url and json headers", () => {
+    const template = new HttpService().getTemplate();
+
+    expect(template).toMatch('import axios from "axios";');
+    expect(template).toMatch(/baseURL: process\.env\.VUE_APP_BASE_URL/);
+    expect(template).toMatch('"Content-Type": "application/json"');
+    expect(template).toMatch("export default httpService;");
+  });
+});
+
+describe("indexStore template", () => {
+  test("registers vuex with persistence and modules", () => {
+    const template = new IndexStore().getTemplate();
+
+    expect(template).toMatch('import Vuex from "vuex";');
+    expect(template).toMatch('import VuexPersistence from "vuex-persist";');
+    expect(template).toMatch("Vue.use(Vuex);");
+    expect(template).toMatch("export default new Vuex.Store({");
+    expect(template).toMatch("plugins: [vuexLocal.plugin]");
+  });
+});
+
+describe("indexModule template", () => {
+  test("auto-loads store modules via require.context", () => {
+    const template = new IndexModule().getTemplate();
+
+    expect(template).toMatch('require.context(".", false, /.js$/)');
+    expect(template).toMatch("export default");
+  });
+});
+
+describe("eslintrc template", () => {
+  test("configures prettier and vue plugins", () => {
+    const template = new Eslintrc().getTemplate();
+
+    expect(template).toMatch("module.exports = {");
+    expect(template).toMatch("'plugin:prettier/recommended'");
+    expect(template).toMatch("'plugin:vue/essential'");
+  });
+});


### PR DESCRIPTION
Completes coverage of the pure scaffold template builders exercised by `Init.generate()` (companions: #38 crud, #39 init, #40 service/module, #41 router):

- `httpService` — axios instance with `VUE_APP_BASE_URL` fallback, JSON content type, default export
- `indexStore` — Vuex store with `vuex-persist` plugin and modules
- `indexModule` — `require.context` auto-load of store modules
- `eslintrc` — generated `.eslintrc.js` with prettier + vue/essential extends

No production changes. jest 40/40 across 9 suites (36 master + 4 new), eslint clean, CLI smoke fine.