### PR TITLE
fix(cli): fail fast when a frontend's templates are missing

### DIFF
--- a/main.js
+++ b/main.js
@@ -96,6 +96,18 @@ const initModel = async () => {
   }
 };
 
+const frontendTemplatesExist = frontend =>
+  fs.existsSync(path.join(__dirname, "js", frontend));
+
+const checkFrontendTemplates = frontend => {
+  if (!frontendTemplatesExist(frontend)) {
+    console.error(
+      `Frontend "${frontend}" templates are not available. Supported frontends: bootstrap.`
+    );
+    process.exit(1);
+  }
+};
+
 const initApp = async () => {
   try {
     if (config.bootstrap) {
@@ -103,6 +115,8 @@ const initApp = async () => {
     } else {
       config.frontend = "vuetify";
     }
+
+    checkFrontendTemplates(config.frontend);
 
     const init = new Init(config);
     init.generate();
@@ -124,6 +138,8 @@ const createTemplates = async (name, model, resource) => {
   } else {
     config.frontend = "vuetify";
   }
+
+  checkFrontendTemplates(config.frontend);
 
   crud = new Crud(config);
   crud.generate();
@@ -232,4 +248,10 @@ if (require.main === module) {
   main();
 }
 
-module.exports = { config, createBaseFolders, createFolder, main };
+module.exports = {
+  config,
+  createBaseFolders,
+  createFolder,
+  frontendTemplatesExist,
+  main
+};

--- a/test/frontend_templates.test.js
+++ b/test/frontend_templates.test.js
@@ -1,0 +1,13 @@
+const { frontendTemplatesExist } = require("../main");
+
+test("bootstrap templates are available", () => {
+  expect(frontendTemplatesExist("bootstrap")).toBe(true);
+});
+
+test("vuetify templates are not shipped (yet)", () => {
+  expect(frontendTemplatesExist("vuetify")).toBe(false);
+});
+
+test("unknown frontends report unavailable", () => {
+  expect(frontendTemplatesExist("nope")).toBe(false);
+});


### PR DESCRIPTION
Papercut fix: `initApp`/`createTemplates` resolve `config.frontend` to `bootstrap` or `vuetify`, but only `js/bootstrap/` templates exist — a vuetify run died deep in `require(`./vuetify/view.js`)` with a raw MODULE_NOT_FOUND.

Now a `checkFrontendTemplates` guard runs right after frontend resolution in both entry points: it prints `Frontend "vuetify" templates are not available. Supported frontends: bootstrap.` and exits cleanly instead of a stack trace. The underlying predicate `frontendTemplatesExist(frontend)` is exported and unit-tested (bootstrap→true, vuetify→false, unknown→false).

Verified: eslint clean, jest 46/46 across 11 suites (43 master + 3 new), CLI smoke (`--version`) fine, +23/-1 in main.js.