### PR TITLE
test(bootstrap): cover the five component templates

### DIFF
--- a/test/bootstrap_templates.test.js
+++ b/test/bootstrap_templates.test.js
@@ -1,0 +1,64 @@
+const model = {
+  title: { type: "text" },
+  price: { type: "currency" },
+  active: {
+    type: "radio",
+    options: [
+      { id: "Active", value: true },
+      { id: "Inactive", value: false }
+    ]
+  },
+  birth: { type: "hiddenFields", options: ["birth"] }
+};
+const resource = { endPoint: "books" };
+
+const template = name => {
+  const Template = require(`../js/bootstrap/${name}`);
+  return new Template("book", model, resource).getTemplate();
+};
+
+describe("bootstrap view template", () => {
+  test("renders the view card with model fields", () => {
+    const view = template("view");
+
+    expect(view).toMatch("View book");
+    expect(view).toMatch(/title/);
+  });
+});
+
+describe("bootstrap form template", () => {
+  test("renders inputs for visible fields only", () => {
+    const form = template("form");
+
+    expect(form).toMatch('id="bookForm"');
+    expect(form).toMatch("handleSubmit");
+    expect(form).toMatch(/title/);
+    expect(form).toMatch(/price/);
+    expect(form).not.toMatch(/birth/);
+  });
+});
+
+describe("bootstrap index template", () => {
+  test("renders the index layout for the model", () => {
+    const index = template("index");
+
+    expect(index).toMatch(/Book/);
+    expect(index).toMatch(/book/);
+  });
+});
+
+describe("bootstrap create and edit templates", () => {
+  test("create wires the form component", () => {
+    const create = template("create");
+
+    expect(create).toMatch("bookCreate");
+    expect(create).toMatch(/BookForm/);
+  });
+
+  test("edit wires the form component", () => {
+    const edit = template("edit");
+
+    expect(edit).toMatch("bookEdit");
+    expect(edit).toMatch(/BookForm/);
+  });
+});


### PR DESCRIPTION
Covers the last uncovered pure template builders, `js/bootstrap/{view,form,index,create,edit}.js`, with a rich fixture model (text, currency, radio-with-options, hiddenFields):

- `view` — renders the `View book` card with model fields
- `form` — renders `bookForm` id, `handleSubmit`, visible fields (title/price) and **excludes `hiddenFields`** (birth) — the key behavioral guarantee
- `index` — renders the model index layout
- `create`/`edit` — wire the `BookForm` component with bookCreate/bookEdit wrappers

No production changes. jest 48/48 across 11 suites (43 master + 5 new), eslint clean, CLI smoke fine.