### PR TITLE
docs(readme): add development section with test/lint/smoke commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,3 +216,32 @@ const model = {
 
 module.exports = { model, resource };
 ```
+
+## Development
+
+To hack on the generator itself:
+
+```bash
+git clone https://github.com/dionmaicon/vue-crudgen.git
+cd vue-crudgen
+npm ci
+```
+
+Run the test suite (jest):
+
+```bash
+npm test
+```
+
+Lint the codebase:
+
+```bash
+npx eslint main.js js test
+```
+
+Smoke the CLI:
+
+```bash
+node main.js --version
+```
+


### PR DESCRIPTION
Docs-only: the README covers CLI usage end-to-end but never mentions how to develop the generator itself. Adds a short **Development** section:

- clone + `npm ci`
- `npm test` (jest suite — 43 tests today, 48 with the open test PRs)
- `npx eslint main.js js test`
- `node main.js --version` smoke check

Verified: jest 43/43, eslint clean, CLI smoke fine (docs change, no code touched).