### PR TITLE
fix(cli): report missing model file instead of crashing

### DIFF
--- a/main.js
+++ b/main.js
@@ -52,6 +52,10 @@ const createFolder = (name, basePath) => {
 
 const createFiles = (name, file) => {
   fs.stat(file, function(err, stats) {
+    if (err) {
+      console.error(`Template model file "${file}" not found.`);
+      return;
+    }
     let basePath = config.pathComponents;
     createFolder(name, basePath);
     const { model, resource } = require(file);

--- a/test/cli_unique_missing.test.js
+++ b/test/cli_unique_missing.test.js
@@ -1,0 +1,17 @@
+const { spawnSync } = require("child_process");
+const path = require("path");
+
+test("missing unique model file reports a friendly error", () => {
+  const result = spawnSync(
+    process.execPath,
+    [path.join(__dirname, "..", "main.js"), "-u", "missing-model.js"],
+    {
+      cwd: path.join(__dirname, ".."),
+      encoding: "utf8",
+      timeout: 60000
+    }
+  );
+
+  expect(result.stderr).toMatch(/missing-model\.js" not found\./);
+  expect(result.stderr).not.toMatch("Cannot find module");
+});


### PR DESCRIPTION
`createFiles` ignored the `fs.stat` error, so `vue-crudgen -u missing-model.js` died with an unhandled async `Cannot find module` stack trace.

Now it prints `Template model file "/abs/path" not found.` and skips generation (+4 lines in main.js).

Covered by `test/cli_unique_missing.test.js`, which spawns the real CLI (repo-root cwd so the trailing `npx eslint` execs resolve locally) and asserts the friendly message appears and no `Cannot find module` leaks.

Verified: eslint clean, jest 44/44 across 11 suites (43 + 1 new), manual CLI run shows the clean message. Deliberately no changes to `module.exports` to avoid conflicting with open PR #43.