### PR TITLE
test(cli): pin --version banner to package.json version

### DIFF
--- a/test/cli_version.test.js
+++ b/test/cli_version.test.js
@@ -1,0 +1,16 @@
+const { spawnSync } = require("child_process");
+const path = require("path");
+const { version } = require("../package.json");
+
+test("--version banner matches package.json", () => {
+  const result = spawnSync(
+    process.execPath,
+    [path.join(__dirname, "..", "main.js"), "--version"],
+    { encoding: "utf8", timeout: 30000 }
+  );
+
+  expect(result.status).toBe(0);
+  expect(result.stdout).toMatch(
+    `Vue.js CRUD-GEN Version: ${version} developed by Dion Maicon - BETA`
+  );
+});


### PR DESCRIPTION
Regression test for the earliest agent fix (463d11c): the `--version` banner used to hardcode `1.0.6` while package.json said `1.0.7`. The test spawns the CLI and asserts the banner embeds the current package.json version verbatim, so future version bumps that forget the banner (in theory impossible now — the banner reads package.json) or regressions to a hardcoded string fail loudly.

New file only — zero conflict surface with the open PR pile. jest 44/44 across 11 suites (43 master + 1 new), eslint clean. `--version` exits before any side effects, so the spawn completes in ~1s.